### PR TITLE
PiledSymbolsFilter

### DIFF
--- a/src/main/java/in/bhargavrao/stackoverflow/natty/filters/PiledSymbolsFilter.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/filters/PiledSymbolsFilter.java
@@ -1,0 +1,40 @@
+package in.bhargavrao.stackoverflow.natty.filters;
+
+import in.bhargavrao.stackoverflow.natty.entities.Post;
+import in.bhargavrao.stackoverflow.natty.utils.CheckUtils;
+
+/**
+ * Checks for piled symbols like ??? or !!!.
+ * 
+ * @note Currently, the value is set to 0.
+ * */
+public class PiledSymbolsFilter implements Filter {
+	private Post post;
+    private double value;
+    private String symbols;
+	
+	
+	public PiledSymbolsFilter(Post post) {
+		this.post = post;
+		this.value = 0;
+		this.symbols = null;
+	}
+	
+	
+	@Override
+	public boolean filter() {
+		this.symbols = CheckUtils.checkForPiledSymbols(this.post);
+		return (this.symbols != null && this.symbols.length() > 0) ? true : false;
+	}
+
+	@Override
+	public double getValue() {
+		return value;
+	}
+
+	@Override
+	public String description() {
+		return "Piled symbols - "+this.symbols;
+	}
+
+}

--- a/src/main/java/in/bhargavrao/stackoverflow/natty/utils/CheckUtils.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/utils/CheckUtils.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.*;
 
 public class CheckUtils {
 
@@ -247,5 +248,15 @@ public class CheckUtils {
             return false;
         }
         return true;
+    }
+    
+    /**
+     * Checks if the post contains piled symbols such as "???" or "!!!"
+     * @returns The matched symbols; null, if the post doesn't contain piled symbols
+     * */
+    public static String checkForPiledSymbols(Post post) {
+    	Pattern regex = Pattern.compile("(\\?{2,}|!{2,})");
+    	Matcher matcher = regex.matcher(post.getBody());
+    	return matcher.find() ? matcher.group(1) : null;
     }
 }

--- a/src/main/java/in/bhargavrao/stackoverflow/natty/utils/PostUtils.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/utils/PostUtils.java
@@ -30,6 +30,7 @@ import in.bhargavrao.stackoverflow.natty.filters.LinkOnlyAnswerFilter;
 import in.bhargavrao.stackoverflow.natty.filters.NoCodeBlockFilter;
 import in.bhargavrao.stackoverflow.natty.filters.NonEnglishFilter;
 import in.bhargavrao.stackoverflow.natty.filters.OneLineFilter;
+import in.bhargavrao.stackoverflow.natty.filters.PiledSymbolsFilter;
 import in.bhargavrao.stackoverflow.natty.filters.ReputationFilter;
 import in.bhargavrao.stackoverflow.natty.filters.SalutationsFilter;
 import in.bhargavrao.stackoverflow.natty.filters.SelfAnswerFilter;
@@ -149,6 +150,7 @@ public class PostUtils {
             add(new NoCodeBlockFilter(np));
             add(new NonEnglishFilter(np));
             add(new OneLineFilter(np));
+            add(new PiledSymbolsFilter(np));
             add(new ReputationFilter(np));
             add(new SalutationsFilter(np));
             add(new SelfAnswerFilter(np));


### PR DESCRIPTION
That was a quick idea I had during dinner. :-D Not sure if this filter is really necessary and useful.

I searched for "??" and "!!!" in Sentinel and found out, that strings like that have lots of tps. So I implemented a filter that checks for matches with this regular expression: `(\?{2,}|!{2,})`

<img width="1070" alt="bildschirmfoto 2017-01-09 um 20 52 46" src="https://cloud.githubusercontent.com/assets/2721240/21780921/a08822fc-d6ad-11e6-985e-b0a60bc372fc.png">


At the moment, the value is at `0`. If you like the idea and want to implement this, we could start with `0.5` or `1.0`.