### PR TITLE
+ add commas to the PiledSymbolsFilter

### DIFF
--- a/src/main/java/in/bhargavrao/stackoverflow/natty/utils/CheckUtils.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/utils/CheckUtils.java
@@ -258,7 +258,7 @@ public class CheckUtils {
     	String cleanPost = CheckUtils.stripBody(post);
     	//System.out.println(cleanPost);
     	
-    	Pattern regex = Pattern.compile("(\\?{2,}|!{2,})");
+    	Pattern regex = Pattern.compile("(\\?{2,}|!{2,}|!,{2,})");
     	Matcher matcher = regex.matcher(cleanPost);
     	return matcher.find() ? matcher.group(1) : null;
     }


### PR DESCRIPTION
Piled commas `,,,` seem to indicate bad posts quite well: https://sentinel.erwaysoftware.com/search?utf8=✓&q=%2C%2C&commit=Search

So I've added them to the regex in the `PiledSymbolsFilter`