### PR TITLE
Bump commons-lang dependency to 3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
             <version>0.5</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>

--- a/src/main/java/in/bhargavrao/stackoverflow/natty/commands/AddCheckUser.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/commands/AddCheckUser.java
@@ -5,7 +5,7 @@ import fr.tunaki.stackoverflow.chat.Room;
 import in.bhargavrao.stackoverflow.natty.services.FileStorageService;
 import in.bhargavrao.stackoverflow.natty.services.StorageService;
 import in.bhargavrao.stackoverflow.natty.utils.CommandUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Created by bhargav.h on 30-Sep-16.

--- a/src/main/java/in/bhargavrao/stackoverflow/natty/commands/OptIn.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/commands/OptIn.java
@@ -8,7 +8,7 @@ import in.bhargavrao.stackoverflow.natty.model.SOUser;
 import in.bhargavrao.stackoverflow.natty.services.FileStorageService;
 import in.bhargavrao.stackoverflow.natty.services.StorageService;
 import in.bhargavrao.stackoverflow.natty.utils.CommandUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Created by bhargav.h on 30-Sep-16.

--- a/src/main/java/in/bhargavrao/stackoverflow/natty/commands/OptOut.java
+++ b/src/main/java/in/bhargavrao/stackoverflow/natty/commands/OptOut.java
@@ -8,7 +8,7 @@ import in.bhargavrao.stackoverflow.natty.model.SOUser;
 import in.bhargavrao.stackoverflow.natty.services.FileStorageService;
 import in.bhargavrao.stackoverflow.natty.services.StorageService;
 import in.bhargavrao.stackoverflow.natty.utils.CommandUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Created by bhargav.h on 30-Sep-16.


### PR DESCRIPTION
While not officially deprecated, Apache Commons Lang 2.6 is a legacy
version, and should probably not be used in a modern project that
requires Java 8.

This patch bumps the requirement to the latest version, 3.6, and
changes the imports appropriately to make the code compile.